### PR TITLE
create routes

### DIFF
--- a/src/routes/assets.ts
+++ b/src/routes/assets.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express'
+
+const router = Router()
+
+router.get('/', () => {})
+
+export default router

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express'
+import usersRouter from './users'
+import assetsRoutes from './assets'
+import ordersRoutes from './orders'
+
+const router = Router()
+
+router.use('/user', usersRouter)
+router.use('/assets', assetsRoutes)
+router.use('/orders', ordersRoutes)
+
+export default router

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express'
+
+const router = Router()
+
+router.post('/', () => {})
+
+export default router

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express'
+
+const router = Router()
+
+router.get('/', () => {})
+
+export default router


### PR DESCRIPTION
Add initial routes for the API

- Added basic routes for `users`, `assets`, and `orders` with empty handlers.
- Set up the main route in `index` to connect route modules and define `/user`, `/assets`, and `/orders`.

Initial structure ready to add logic to each endpoint.
