### PR TITLE
add validate query in get instruments

### DIFF
--- a/src/middlewares/instrument.ts
+++ b/src/middlewares/instrument.ts
@@ -1,0 +1,7 @@
+import { Request, Response, NextFunction } from 'express'
+import { querySearchInstrumentsValidator } from './requestValidator'
+import { searchQueryInstrumentSchema } from '../schemas/instrument'
+
+export const validatorQueryParameters = (req: Request, res: Response, next: NextFunction): void => {
+  querySearchInstrumentsValidator<typeof searchQueryInstrumentSchema>(req, res, next, searchQueryInstrumentSchema)
+}

--- a/src/middlewares/requestValidator.ts
+++ b/src/middlewares/requestValidator.ts
@@ -54,3 +54,24 @@ export const paramsUserValidator = async <T extends ZodSchema<{ params: any }>>(
     res.status(400).json({ message: error.message })
   }
 }
+
+export const querySearchInstrumentsValidator = async <T extends ZodSchema<{ query: any }>>(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  schema: T
+): Promise<void> => {
+  try {
+    const result = schema.safeParse(req)
+
+    if (!result.success) {
+      throw result.error
+    }
+
+    req.query = result.data.query
+
+    return next()
+  } catch (error: any) {
+    res.status(400).json({ message: error.message })
+  }
+}

--- a/src/routes/instrument.ts
+++ b/src/routes/instrument.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express'
 import InstrumentsController from '../controllers/instrument'
+import { validatorQueryParameters } from '../middlewares/instrument'
 
 const router = Router()
 
-router.get('/search', InstrumentsController.getInstruments)
+router.get('/search', validatorQueryParameters, InstrumentsController.getInstruments)
 
 export default router

--- a/src/schemas/instrument.ts
+++ b/src/schemas/instrument.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const InstrumentSearchQuerySchema = z.object({
+  ticker: z.string().optional(),
+  name: z.string().optional()
+}).refine((data) => data.ticker || data.name, {
+  message: "At least one of the 'ticker' or 'name' fields must be present.",
+  path: []
+})
+
+export const searchQueryInstrumentSchema = z.object({
+  query: InstrumentSearchQuerySchema
+})
+
+export type IParamsUser = z.infer<typeof searchQueryInstrumentSchema>

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -1,4 +1,4 @@
-import { number, z } from 'zod'
+import { z } from 'zod'
 
 export const UserParamsSchema = z.object({
  userId: z.string().regex(/^\d+$/).transform(Number)


### PR DESCRIPTION
Add validation on instrument search endpoint using query parameters (GET /search)

- Validation middleware: The validatorQueryParameters middleware is created, which uses querySearchInstrumentsValidator to validate the query parameters in req.query according to the searchQueryInstrumentSchema schema. If the validation fails, a 400 error response will be returned with the corresponding message.

- Validation scheme: InstrumentSearchQuerySchema is defined using Zod to validate that at least one of the ticker or name fields is present in the query. This schema is included in searchQueryInstrumentSchema to allow an organized structure of search parameters.

- Path Integration: The validatorQueryParameters middleware is applied to the GET /search path within the instrument.ts path file, ensuring that all requests pass through validation before accessing the InstrumentsController.getInstruments controller.

This ensures that instrument search requests include at least one valid parameter, improving the robustness and accuracy of the queries.